### PR TITLE
README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ edgelist <- infer_edgelist(
   cat_combo_list = feeding_rules,
   col_taxon = "species",
   certainty_req = "all",
-  allow_self = FALSE
 )
 
 # Show first few interactions

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ devtools::install_github("BecksLab/pfwim")
 ## Load Example Data
 
 ```
-library(pfwim.R)
+library(pfwim)
 
 # Trait data
 data("traits", package = "pfwim")


### PR DESCRIPTION
Update README file.

Adjust package name in `library()` example, remove `.R` extension.

Adjust `infer_edgelist()` example, removing `allow_self = FALSE` option, which causes error.

The example matches that in th workflow vignette, but a more complete fix may require code adjustments.

This pull request addresses issues #2 and #3.